### PR TITLE
Vwap & Twap Subscriber

### DIFF
--- a/appconfig/passwords/accesslist.txt
+++ b/appconfig/passwords/accesslist.txt
@@ -17,3 +17,4 @@ metrics:pass
 vwapsub:pass
 checker:pass
 admin:admin
+vtwap:pass

--- a/appconfig/passwords/vtwap.txt
+++ b/appconfig/passwords/vtwap.txt
@@ -1,0 +1,1 @@
+vtwap:pass

--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -20,3 +20,4 @@ localhost,{KDBBASEPORT}+17,sortslave,sortslave2
 localhost,{KDBBASEPORT}+18,metrics,metrics1
 localhost,{KDBBASEPORT}+19,iexfeed,iexfeed1
 localhost,{KDBBASEPORT}+20,checker,symcheck
+localhost,{KDBBASEPORT}+21,vtwap,vtwap1

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -27,7 +27,7 @@ subscribe:{[]
   if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];
     .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];                          // set the date that was returned by the subscription code i.e. the date for the tickerplant log file
     subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                        // and a list of the tables that the process is now subscribing for
-    @[`.vtwap;;:;]'[key subinfo;value subinfo];                                                        // setting subtables and tplogdate globals
+    @[`.vtwap;key subinfo;:;value subinfo];                                                            // setting subtables and tplogdate globals
     ];
  };
 notpconnected:{[]
@@ -48,7 +48,7 @@ while[                                                                          
 
 upd:.vtwap.upd;                                                                                        // set the upd function in the top level namespace
 
-getvwap:{[syms;st;et]                                                                                  // 
+getvwap:{[syms;st;et]                                                                                  // calculate VWAP for a list of syms. st and et as times
   :raze{[st;et;sym]
     :([]enlist sym),'
     select vwap:size wavg price from .vtwap.data[sym]
@@ -56,10 +56,10 @@ getvwap:{[syms;st;et]                                                           
   }[st;et]'[syms];
  };
 
-gettwap:{[syms;st;et]
+gettwap:{[syms;st;et]										       // calculate TWAP for a list of syms. se and et as times
   :raze{[st;et;sym]
-    i:bin[t:"n"$(d:.vtwap.data sym)`time;(st;et)];
-    ind:i[0]+til i[1]+1-i 0;
-    :([]enlist sym;enlist twap:deltas[st;1_t[ind],et]wavg d[`price]ind);
+    i:bin[t:"n"$(d:.vtwap.data sym)`time;(st;et)];						       // get first and last index of times
+    ind:i[0]+til i[1]+1-i 0;									       // get full list of indices
+    :([]enlist sym;enlist twap:deltas[st;1_t[ind],et]wavg d[`price]ind);                              
    }["n"$st;"n"$et]'[syms];
   };

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -1,0 +1,78 @@
+/-default parameters
+
+// replay logfile
+tab:flip`time`sym`price`size`stop`cond`ex!();
+upd:{[t;x]
+  if[`trade=t;
+  .vtwap.upd[t;tab upsert@[flip;x;enlist x]];
+  ];
+ };
+
+\d .vtwap
+
+tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                              // list of tickerplant types to try and make a connection to
+replaylog:@[value;`replaylog;1b];                                                                      // replay the tickerplant log file
+schema:@[value;`schema;0b];                                                                            // retrieve the schema from the tickerplant
+subscribeto:@[value;`subscribeto;`trade`trade_iex];                                                                   /////// a list of tables to subscribe to, default (`) means all tables
+subscribesyms:@[value;`subscribesyms;`];                                                               // a list of syms to subscribe for, (`) means all syms
+tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                          // number of seconds between attempts to connect to the tp
+
+// For TWAP - only store last trade in batch of same times?
+// fix on monday
+upd:{[t;x]
+  syms:exec distinct sym from x;
+  if[any `trade`trade_iex=/t;
+    .twap.twap:@[value;`.twap.twap;syms!()];
+    .vwap.vwap:@[value;`.vwap.vwap;syms!()];
+    createtable[`.twap.twap;exec enlist last([]time;price)by sym from x]'[syms];
+    createtable[`.vwap.vwap;exec([]time;price;size)by sym from x]'[syms];
+   ];
+ };
+
+createtable:{[tab;x;y]@[tab;y;upsert;x y]};
+
+subscribe:{[]
+        if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];;
+                .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];
+                /-set the date that was returned by the subscription code i.e. the date for the tickerplant log file
+                /-and a list of the tables that the process is now subscribing for
+                subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];
+                /-setting subtables and tplogdate globals
+                @[`.vtwap;;:;]'[key subinfo;value subinfo]]}
+notpconnected:{[]
+    0 = count select from .sub.SUBSCRIPTIONS where proctype in .vtwap.tickerplanttypes, active}
+\d .
+.servers.CONNECTIONS:distinct .servers.CONNECTIONS,.vtwap.tickerplanttypes
+
+/-set the upd function in the top level namespace
+tschema:flip `time`sym`price`size!()
+.lg.o[`init;"searching for servers"];
+.servers.startup[]; 
+/-subscribe to the tickerplant
+.vtwap.subscribe[];
+/-check if the tickerplant has connected, block the process until a connection is established
+while[.vtwap.notpconnected[];
+        /-while no connected make the process sleep for X seconds and then run the subscribe function again
+        .os.sleep[.vtwap.tpconnsleepintv];
+        /-run the servers startup code again (to make connection to discovery)
+        .servers.startup[];
+        .vtwap.subscribe[]]
+
+upd:.vtwap.upd;
+
+getvwap:{[syms;st;et]
+  :raze{[syms;st;et]
+    :([]enlist sym:syms),'
+    select vwap:size wavg price from .vwap.vwap[syms] 
+      where time within(st;et);
+  }[;st;et]'[syms];
+ };
+
+gettwap:{[syms;st;et]
+  :raze{[syms;et;st]
+    :([]enlist sym:syms),'
+    select twap:(next[time]-time) wavg price from .twap.twap[syms]
+      where time within(st;et);
+   }[;st;et]'[syms];
+ };
+

--- a/code/processes/vtwap.q
+++ b/code/processes/vtwap.q
@@ -1,75 +1,65 @@
-// replay logfile
 tab:flip`time`sym`price`size`stop`cond`ex!();
 upd:{[t;x]
-  if[t=`trade;
-    syms:distinct x 1;
-    .vtwap.data:@[value;`.vtwap.data;syms!()];
-    .vtwap.createtable[`.vtwap.data;exec([]time;price;size)by sym from (tab upsert @[flip;x;enlist x])]'[syms]
-    ];
+  if[t<>`trade;:()];
+  syms:distinct x 1;
+  .vtwap.data:@[value;`.vtwap.data;syms!()];
+  .vtwap.addrows[`.vtwap.data;exec([]time;price;size)by sym from (tab upsert @[flip;x;enlist x])]'[syms];
  };
 
 \d .vtwap
-
 tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];                                              // list of tickerplant types to try and make a connection to
 replaylog:@[value;`replaylog;1b];                                                                      // replay the tickerplant log file
 schema:@[value;`schema;0b];                                                                            // retrieve the schema from the tickerplant
-subscribeto:@[value;`subscribeto;`trade`trade_iex];                                                                   /////// a list of tables to subscribe to, default (`) means all tables
+subscribeto:@[value;`subscribeto;`trade`trade_iex];                                                    // a list of tables to subscribe to, default (`) means all tables
 subscribesyms:@[value;`subscribesyms;`];                                                               // a list of syms to subscribe for, (`) means all syms
 tpconnsleepintv:@[value;`tpconnsleepintv;10];                                                          // number of seconds between attempts to connect to the tp
 
 upd:{[t;x]
+  if[t<>`trade;:()];
   syms:exec distinct sym from x;
-  if[`trade=t;
-    .vtwap.data:@[value;`.vtwap.data;syms!()];
-    createtable[`.vtwap.data;exec([]time;price;size)by sym from x]'[syms];
-   ];
+  .vtwap.data:@[value;`.vtwap.data;syms!()];
+  addrows[`.vtwap.data;exec([]time;price;size)by sym from x]'[syms];
  };
 
-createtable:{[tab;x;y]@[tab;y;upsert;x y]};
+addrows:{[tab;x;y]@[tab;y;upsert;x y]};
 
 subscribe:{[]
-  if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];;
-    .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];
-    /-set the date that was returned by the subscription code i.e. the date for the tickerplant log file
-    /-and a list of the tables that the process is now subscribing for
-    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];
-    /-setting subtables and tplogdate globals
-    @[`.vtwap;;:;]'[key subinfo;value subinfo];
+  if[count s:.sub.getsubscriptionhandles[tickerplanttypes;();()!()];
+    .lg.o[`subscribe;"found available tickerplant, attempting to subscribe"];                          // set the date that was returned by the subscription code i.e. the date for the tickerplant log file
+    subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];                        // and a list of the tables that the process is now subscribing for
+    @[`.vtwap;;:;]'[key subinfo;value subinfo];                                                        // setting subtables and tplogdate globals
     ];
  };
 notpconnected:{[]
-    0 = count select from .sub.SUBSCRIPTIONS where proctype in .vtwap.tickerplanttypes, active}
+    :0 = count select from .sub.SUBSCRIPTIONS where proctype in .vtwap.tickerplanttypes, active;
+ };
 \d .
 .servers.CONNECTIONS:distinct .servers.CONNECTIONS,.vtwap.tickerplanttypes
 
-/-set the upd function in the top level namespace
 .lg.o[`init;"searching for servers"];
 .servers.startup[]; 
-/-subscribe to the tickerplant
-.vtwap.subscribe[];
-/-check if the tickerplant has connected, block the process until a connection is established
-while[.vtwap.notpconnected[];
-  /-while no connected make the process sleep for X seconds and then run the subscribe function again
-  .os.sleep[.vtwap.tpconnsleepintv];
-  /-run the servers startup code again (to make connection to discovery)
-  .servers.startup[];
-  .vtwap.subscribe[]
-  ]
+.vtwap.subscribe[];                                                                                    // subscribe to the tickerplant
+while[                                                                                                 // check if the tickerplant has connected, block the process until a connection is established
+  .vtwap.notpconnected[];
+  .os.sleep .vtwap.tpconnsleepintv;                                                                    // while no connected make the process sleep for X seconds and then run the subscribe function again
+  .servers.startup[];                                                                                  // run the servers startup code again (to make connection to discovery)
+  .vtwap.subscribe[];
+  ];
 
-upd:.vtwap.upd;
+upd:.vtwap.upd;                                                                                        // set the upd function in the top level namespace
 
-getvwap:{[syms;st;et]
-  :raze{[syms;st;et]
-    :([]enlist sym:syms),'
-    select vwap:size wavg price from .vtwap.data[syms]
+getvwap:{[syms;st;et]                                                                                  // 
+  :raze{[st;et;sym]
+    :([]enlist sym),'
+    select vwap:size wavg price from .vtwap.data[sym]
       where time within(st;et);
-  }[;st;et]'[syms];
+  }[st;et]'[syms];
  };
 
 gettwap:{[syms;st;et]
-  :raze{[sym;st;et]
-    i:bin[t:"n"$(d:.vtwap.data[sym])`time;(st;et)];
+  :raze{[st;et;sym]
+    i:bin[t:"n"$(d:.vtwap.data sym)`time;(st;et)];
     ind:i[0]+til i[1]+1-i 0;
-    :([]enlist sym:sym;enlist twap:(deltas[st;1_t[ind],et])wavg d[`price]ind);
-   }[;"n"$st;"n"$et]'[syms];
+    :([]enlist sym;enlist twap:deltas[st;1_t[ind],et]wavg d[`price]ind);
+   }["n"$st;"n"$et]'[syms];
   };

--- a/start_torq_demo.sh
+++ b/start_torq_demo.sh
@@ -79,5 +79,20 @@ echo 'Starting sort slave-2...'
 nohup q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortslave -procname sortslave2 -localtime -g 1 </dev/null >$KDBLOG/torqsortslave2.txt 2>&1 &
 
 # launch metrics
-echo 'Stating metrics...'
+echo 'Starting metrics...'
 nohup q torq.q -load code/processes/metrics.q ${KDBSTACKID} -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1 </dev/null >$KDBLOG/torqmetrics.txt 2>&1 &
+
+# launch symcheck
+echo 'Starting symcheck...'
+nohup q torq.q -load code/checks/symcheck.q ${KDBSTACKID} -proctype checker -procname symcheck1 appconfig/passwords/accesslist.txt -localtime -g 1 -T 30 -.symcheck.tm1 0D00:00:15.000000000 -.symcheck.wn1 0D00:00:00.000000001 </dev/null >$KDBLOG/torqsymcheck.txt 2>&1 &
+
+# launch eodsummary
+echo 'Starting eodsummary...'
+nohup q torq.q -load code/eodsummary/eodsummary.q ${KDBSTACKID} -proctype metrics -procname eodsummary1 appconfig/passwords/accesslist.txt -localtime -g 1 -T 30 </dev/null >$KDBLOG/torqeodsummary.txt 2>&1 &
+
+# launch vtwap
+echo 'Starting vtwap...'
+nohup q ${TORQHOME}/torq.q -load code/processes/vtwap.q ${KDBSTACKID} -proctype vtwap -procname vtwap1 -U appconfig/passwords/accesslist.txt -localtime -g 1 </dev/null >$KDBLOG/torqvtwap.txt 2>&1 &
+
+
+

--- a/stop_torq_demo.sh
+++ b/stop_torq_demo.sh
@@ -3,4 +3,4 @@
 
 #kill all torq procs
 echo 'Shutting down TorQ...'
-q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortslave iexfeed feed rdb tickerplant chainedtp hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics </dev/null >$KDBLOG/torqkill.txt 2>&1 &
+q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortslave iexfeed feed rdb tickerplant chainedtp hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics vtwap checker  </dev/null >$KDBLOG/torqkill.txt 2>&1 &


### PR DESCRIPTION
Torq process for for calculating twap and vwap on demand.

Subscribes to TP, replays log file and keeps a summary table `.vtwap.data` with `time, price, size` for each sym.

`getvwap` and `gettwap` functions could be better optimised.

Still needs an eod flush to occur.

